### PR TITLE
Implemented #16.

### DIFF
--- a/src/main/java/de/isibboi/agentsim/AgentSim.java
+++ b/src/main/java/de/isibboi/agentsim/AgentSim.java
@@ -42,14 +42,14 @@ public class AgentSim implements Runnable, WindowListener {
 
 	@Override
 	public void run() {
-		FrameRateStabilizer frameRateStabilizer = new FrameRateStabilizer(
+		FrameRateStabilizer frameRateStabilizer = new SlowFrameRateStabilizer(
 				_settings.getInt(Settings.CORE_TARGET_FRAME_RATE),
 				_settings.getInt(Settings.CORE_TARGET_UPDATE_RATE),
 				_settings.getInt(Settings.CORE_MAX_UPDATES_PER_FRAME));
 
 		while (!_exit) {
 			if (frameRateStabilizer.stabilize()) {
-				_frame.render();
+				_frame.render(frameRateStabilizer.getTransition());
 			} else {
 				_frame.update();
 			}

--- a/src/main/java/de/isibboi/agentsim/FrameRateStabilizer.java
+++ b/src/main/java/de/isibboi/agentsim/FrameRateStabilizer.java
@@ -1,94 +1,25 @@
 package de.isibboi.agentsim;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 /**
- * A simple stabilizer for the frame rate.
- * 
  * @author Sebastian Schmidt
- * @since 0.2.0
+ * @since 
+ *
  */
-public class FrameRateStabilizer {
-	private final Logger _log = LogManager.getLogger(getClass());
-
-	private long _lastFrameTime;
-	private double _updatesBeforeNextFrame;
-	private final long _targetFrameTime;
-	private final double _targetUpdatesPerFrame;
-	private final int _maxUpdatesPerFrame;
+public interface FrameRateStabilizer {
 
 	/**
-	 * Creates a new {@link FrameRateStabilizer}.
+	 * The transition parameter determines where the entity is exactly drawn.
+	 * For zero, the entity should be drawn at the location from the last update, for one, it should be drawn at the current location.
+	 * Values between zero and one should be used for linear interpolation between old and new location.
 	 * 
-	 * @param framesPerSecond The frame rate to stabilize at.
-	 * @param updatesPerSecond The target amount of updates per second.
-	 * @param maxUpdatesPerFrame The maximum amount of updates per frame.
+	 * @return Returns the transition value for the current update.
 	 */
-	public FrameRateStabilizer(final double framesPerSecond, final double updatesPerSecond, final int maxUpdatesPerFrame) {
-		_targetFrameTime = (long) (1e9 / framesPerSecond);
-		_targetUpdatesPerFrame = updatesPerSecond / framesPerSecond;
-		_maxUpdatesPerFrame = maxUpdatesPerFrame;
-		_lastFrameTime = System.nanoTime();
-	}
+	double getTransition();
 
 	/**
-	 * Waits if necessary to keep the required frame rate. Should be called once per frame.
+	 * Decides if the next step should be an update or a render step. Waits if necessary to keep the desired frame and update rate.
 	 * 
 	 * @return True if a new frame should be rendered, false if the game should be updated.
 	 */
-	public boolean stabilize() {
-		final long currentTime = System.nanoTime();
-
-		if (_updatesBeforeNextFrame > 1.0001) {
-			return update();
-		} else {
-			long waitingTime = (long) (_targetFrameTime - (currentTime - _lastFrameTime));
-
-			if (waitingTime > 0) {
-				try {
-					Thread.sleep(waitingTime / 1_000_000, (int) (waitingTime % 1_000_000));
-				} catch (InterruptedException e) {
-					_log.fatal("Waiting interrupted!", e);
-				}
-			}
-
-			double normalizedFrameTime = 1.0 * (currentTime - _lastFrameTime) / _targetFrameTime;
-			_lastFrameTime = System.nanoTime();
-			return render(normalizedFrameTime);
-		}
-	}
-
-	/**
-	 * Counts the game updates.
-	 * 
-	 * @return False.
-	 */
-	private boolean update() {
-		_updatesBeforeNextFrame--;
-		return false;
-	}
-
-	/**
-	 * Resets the game updates.
-	 * 
-	 * @param normalizedFrameTime The frame time. 1.0 means the frame took exactly as long as it should, values greater than one mean it took longer.
-	 * @return True.
-	 */
-	private boolean render(final double normalizedFrameTime) {
-		_updatesBeforeNextFrame += _targetUpdatesPerFrame * (Math.max(1.0, normalizedFrameTime));
-
-		if (_updatesBeforeNextFrame > _maxUpdatesPerFrame) {
-			_updatesBeforeNextFrame = _maxUpdatesPerFrame;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Resets the stabilizer. This should e.g. be used after pausing the rendering.
-	 */
-	public void reset() {
-		_lastFrameTime = System.nanoTime();
-	}
+	boolean stabilize();
 }

--- a/src/main/java/de/isibboi/agentsim/Settings.java
+++ b/src/main/java/de/isibboi/agentsim/Settings.java
@@ -37,11 +37,14 @@ public class Settings {
 	public static final String CORE_TARGET_UPDATE_RATE = "core.targetUpdateRate";
 	public static final String CORE_MAX_UPDATES_PER_FRAME = "core.maxUpdatesPerFrame";
 
+	public static final String CORE_RENDER_TRANSITION_AMOUNT = "core.render.transitionAmount";
+
 	private static final Set<String> ALL_SETTINGS = new HashSet<>(Arrays.asList(
 			UI_WIDTH, UI_HEIGHT, UI_X_POS, UI_Y_POS, UI_FONT_FAMILY,
 			GAME_INITIAL_GOBLIN_COUNT, GAME_SPAWN_RADIUS, GAME_SCALE,
 			GAME_ENTITIES_GOBLIN_INITIAL_SATURATION,
-			CORE_TARGET_FRAME_RATE, CORE_TARGET_UPDATE_RATE, CORE_MAX_UPDATES_PER_FRAME));
+			CORE_TARGET_FRAME_RATE, CORE_TARGET_UPDATE_RATE, CORE_MAX_UPDATES_PER_FRAME,
+			CORE_RENDER_TRANSITION_AMOUNT));
 
 	private final Logger _log = LogManager.getLogger(getClass());
 
@@ -100,6 +103,8 @@ public class Settings {
 		_defaults.setProperty(CORE_TARGET_FRAME_RATE, "60");
 		_defaults.setProperty(CORE_TARGET_UPDATE_RATE, "60");
 		_defaults.setProperty(CORE_MAX_UPDATES_PER_FRAME, "2");
+
+		_defaults.setProperty(CORE_RENDER_TRANSITION_AMOUNT, "1");
 	}
 
 	/**
@@ -131,6 +136,15 @@ public class Settings {
 	}
 
 	/**
+	 * Sets a setting to the given double.
+	 * @param key The name of the setting.
+	 * @param value The new value of the setting.
+	 */
+	public void set(final String key, final double value) {
+		set(key, Double.toString(value));
+	}
+
+	/**
 	 * Returns the value of a setting.
 	 * @param key The name of the setting.
 	 * @return The value of the setting.
@@ -154,10 +168,25 @@ public class Settings {
 		String value = get(key);
 
 		try {
-			int result = Integer.parseInt(value);
-			return result;
+			return Integer.parseInt(value);
 		} catch (NumberFormatException e) {
 			_log.error("Setting is not an int: (" + key + ": " + value + ")", e);
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	/**
+	 * Returns the value of a given setting as double.
+	 * @param key The name of the setting.
+	 * @return The value of the setting.
+	 */
+	public double getDouble(final String key) {
+		String value = get(key);
+
+		try {
+			return Double.parseDouble(value);
+		} catch (NumberFormatException e) {
+			_log.error("Setting is not a double: (" + key + ": " + value + ")", e);
 			throw new IllegalArgumentException(e);
 		}
 	}

--- a/src/main/java/de/isibboi/agentsim/SimpleFrameRateStabilizer.java
+++ b/src/main/java/de/isibboi/agentsim/SimpleFrameRateStabilizer.java
@@ -1,0 +1,107 @@
+package de.isibboi.agentsim;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * A simple stabilizer for the frame rate.
+ * Does not calculate the correct transition.
+ * {@link #getTransition()} always returns 1.
+ * 
+ * @author Sebastian Schmidt
+ * @since 0.2.0
+ */
+public class SimpleFrameRateStabilizer implements FrameRateStabilizer {
+	private final Logger _log = LogManager.getLogger(getClass());
+
+	private long _lastFrameTime;
+	private double _updatesBeforeNextFrame;
+	private final long _targetFrameTime;
+	private final double _targetUpdatesPerFrame;
+	private final int _maxUpdatesPerFrame;
+
+	/**
+	 * Creates a new {@link SimpleFrameRateStabilizer}.
+	 * 
+	 * @param framesPerSecond The frame rate to stabilize at.
+	 * @param updatesPerSecond The target amount of updates per second.
+	 * @param maxUpdatesPerFrame The maximum amount of updates per frame.
+	 */
+	public SimpleFrameRateStabilizer(final double framesPerSecond, final double updatesPerSecond, final int maxUpdatesPerFrame) {
+		_targetFrameTime = (long) (1e9 / framesPerSecond);
+		_targetUpdatesPerFrame = updatesPerSecond / framesPerSecond;
+		_maxUpdatesPerFrame = maxUpdatesPerFrame;
+
+		reset();
+	}
+
+	@Override
+	public boolean stabilize() {
+		final long currentTime = System.nanoTime();
+
+		if (_updatesBeforeNextFrame >= 1) {
+			return update();
+		} else {
+			long waitingTime = (long) (_targetFrameTime - (currentTime - _lastFrameTime));
+
+			if (waitingTime > 0) {
+				try {
+					Thread.sleep(waitingTime / 1_000_000, (int) (waitingTime % 1_000_000));
+				} catch (InterruptedException e) {
+					_log.fatal("Waiting interrupted!", e);
+				}
+			}
+
+			double normalizedFrameTime = 1.0 * (currentTime - _lastFrameTime) / _targetFrameTime;
+			_lastFrameTime = System.nanoTime();
+			return render(normalizedFrameTime);
+		}
+	}
+
+	/**
+	 * Counts the game updates.
+	 * 
+	 * @return False.
+	 */
+	protected boolean update() {
+		_updatesBeforeNextFrame--;
+		return false;
+	}
+
+	/**
+	 * Resets the game updates.
+	 * 
+	 * @param normalizedFrameTime The frame time. 1.0 means the frame took exactly as long as it should, values greater than one mean it took longer.
+	 * @return True.
+	 */
+	protected boolean render(final double normalizedFrameTime) {
+		_updatesBeforeNextFrame += _targetUpdatesPerFrame * (Math.max(1.0, normalizedFrameTime));
+
+		if (_updatesBeforeNextFrame > _maxUpdatesPerFrame) {
+			_updatesBeforeNextFrame = _maxUpdatesPerFrame;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Resets the stabilizer. This should e.g. be used after pausing the rendering.
+	 */
+	public void reset() {
+		_lastFrameTime = System.nanoTime();
+	}
+
+	@Override
+	public double getTransition() {
+		return 1; // No transition when using fast updates.
+	}
+
+	/**
+	 * Returns the amount of updates that will be made before the next frame is rendered.
+	 * This can be lower than one, if there are more than one renders per update.
+	 * @return The amount of updates before the next frame is rendered.
+	 */
+	protected double getUpdatesBeforeNextFrame() {
+		return _updatesBeforeNextFrame;
+	}
+}

--- a/src/main/java/de/isibboi/agentsim/SlowFrameRateStabilizer.java
+++ b/src/main/java/de/isibboi/agentsim/SlowFrameRateStabilizer.java
@@ -1,0 +1,41 @@
+package de.isibboi.agentsim;
+
+/**
+ * A frame rate stabilizer that adds the transition calculation to the {@link SimpleFrameRateStabilizer}.
+ * 
+ * @author Sebastian Schmidt
+ * @since 0.3.0
+ *
+ */
+public class SlowFrameRateStabilizer extends SimpleFrameRateStabilizer {
+	private double _transition;
+
+	/**
+	 * Creates a new {@link SlowFrameRateStabilizer}.
+	 * 
+	 * @param framesPerSecond The frame rate to stabilize at.
+	 * @param updatesPerSecond The target amount of updates per second.
+	 * @param maxUpdatesPerFrame The maximum amount of updates per frame.
+	 */
+	public SlowFrameRateStabilizer(final double framesPerSecond, final double updatesPerSecond, final int maxUpdatesPerFrame) {
+		super(framesPerSecond, updatesPerSecond, maxUpdatesPerFrame);
+	}
+
+	@Override
+	protected boolean render(final double normalizedFrameTime) {
+		boolean result = super.render(normalizedFrameTime);
+
+		_transition = getUpdatesBeforeNextFrame();
+
+		if (_transition > 1) {
+			_transition = 1;
+		}
+
+		return result;
+	}
+
+	@Override
+	public double getTransition() {
+		return _transition;
+	}
+}

--- a/src/main/java/de/isibboi/agentsim/game/entities/Drawable.java
+++ b/src/main/java/de/isibboi/agentsim/game/entities/Drawable.java
@@ -10,7 +10,12 @@ import java.awt.Graphics2D;
 public interface Drawable {
 	/**
 	 * Draw the object on the screen.
+	 * The transition parameter determines where the entity is exactly drawn.
+	 * For zero, the entity should be drawn at the location from the last update, for one, it should be drawn at the current location.
+	 * Values between zero and one should be used for linear interpolation between old and new location.
+	 * 
 	 * @param g The screen graphics.
+	 * @param transition A value between zero and one.
 	 */
-	void draw(Graphics2D g);
+	void draw(Graphics2D g, double transition);
 }

--- a/src/main/java/de/isibboi/agentsim/game/entities/Entities.java
+++ b/src/main/java/de/isibboi/agentsim/game/entities/Entities.java
@@ -130,9 +130,9 @@ public class Entities implements Collection<Entity>, Updateable, Drawable {
 	}
 
 	@Override
-	public void draw(final Graphics2D g) {
+	public void draw(final Graphics2D g, final double transition) {
 		for (Entity entity : _entities) {
-			entity.draw(g);
+			entity.draw(g, transition);
 		}
 	}
 }

--- a/src/main/java/de/isibboi/agentsim/game/entities/Goblin.java
+++ b/src/main/java/de/isibboi/agentsim/game/entities/Goblin.java
@@ -47,11 +47,13 @@ public class Goblin extends MapEntity {
 	@Override
 	public void draw(final Graphics2D g) {
 		g.setColor(_color);
-		g.fillRect(getLocation().getX(), getLocation().getY(), 1, 1);
+		g.fillRect(0, 0, 1, 1);
 	}
 
 	@Override
 	public void update(final Random random, final int tick) throws GameUpdateException {
+		super.update(random, tick);
+
 		updateAttributes();
 
 		if (!_attributes.isAlive()) {

--- a/src/main/java/de/isibboi/agentsim/game/entities/MapEntity.java
+++ b/src/main/java/de/isibboi/agentsim/game/entities/MapEntity.java
@@ -1,6 +1,11 @@
 package de.isibboi.agentsim.game.entities;
 
+import java.awt.Graphics2D;
+import java.awt.geom.AffineTransform;
+import java.util.Random;
+
 import de.isibboi.agentsim.game.EntityLocationManager;
+import de.isibboi.agentsim.game.GameUpdateException;
 import de.isibboi.agentsim.game.map.GameMap;
 import de.isibboi.agentsim.game.map.Point;
 
@@ -12,6 +17,7 @@ import de.isibboi.agentsim.game.map.Point;
  */
 public abstract class MapEntity implements Entity {
 	private final EntityLocationManager _entityLocationManager;
+	private Point _oldLocation;
 
 	/**
 	 * Creates a new map entity at the given location.
@@ -52,4 +58,46 @@ public abstract class MapEntity implements Entity {
 	public EntityLocationManager getEntityLocationManager() {
 		return _entityLocationManager;
 	}
+
+	@Override
+	public void update(final Random random, final int tick) throws GameUpdateException {
+		_oldLocation = getLocation();
+	}
+
+	/**
+	 * Returns the location of the entity from the last update.
+	 * @return The old location.
+	 */
+	protected Point getOldLocation() {
+		return _oldLocation;
+	}
+
+	@Override
+	public void draw(final Graphics2D g, final double transition) {
+		if (transition < 0 || transition > 1) {
+			throw new IllegalArgumentException("Transition must be in the interval [0, 1]!");
+		}
+
+		Point location = getLocation();
+
+		if (_oldLocation == null) {
+			_oldLocation = location;
+		}
+
+		double x = (1 - transition) * _oldLocation.getX() + transition * location.getX();
+		double y = (1 - transition) * _oldLocation.getY() + transition * location.getY();
+
+		AffineTransform old = g.getTransform();
+		g.translate(x, y);
+
+		draw(g);
+
+		g.setTransform(old);
+	}
+
+	/**
+	 * Draws the entity in the unit rectangle, with coordinates from (0, 0) to (1, 1).
+	 * @param g The graphics object used for drawing.
+	 */
+	protected abstract void draw(final Graphics2D g);
 }

--- a/src/main/java/de/isibboi/agentsim/game/map/GameMap.java
+++ b/src/main/java/de/isibboi/agentsim/game/map/GameMap.java
@@ -47,7 +47,7 @@ public class GameMap implements Drawable {
 	}
 
 	@Override
-	public void draw(final Graphics2D g) {
+	public void draw(final Graphics2D g, final double transition) {
 		g.drawImage(_map, 0, 0, null);
 	}
 

--- a/src/main/java/de/isibboi/agentsim/ui/AgentFrame.java
+++ b/src/main/java/de/isibboi/agentsim/ui/AgentFrame.java
@@ -28,6 +28,7 @@ public class AgentFrame {
 	private Game _game;
 	private View _view;
 	private int _tick;
+	private double _transitionFactor;
 	private final MouseEventTranslator _mouseEventTranslator;
 
 	private final Random _random = new Random();
@@ -53,6 +54,8 @@ public class AgentFrame {
 		_mouseEventTranslator = new MouseEventTranslator(_view);
 		_drawFrame.getContentPane().addMouseListener(_mouseEventTranslator);
 		_drawFrame.getContentPane().addMouseMotionListener(_mouseEventTranslator);
+
+		_transitionFactor = 1 / settings.getDouble(Settings.CORE_RENDER_TRANSITION_AMOUNT);
 
 		start();
 	}
@@ -88,13 +91,23 @@ public class AgentFrame {
 
 	/**
 	 * Renders the map and all entities.
+	 * The transition parameter determines where the entity is exactly drawn.
+	 * For zero, the entity should be drawn at the location from the last update, for one, it should be drawn at the current location.
+	 * Values between zero and one should be used for linear interpolation between old and new location.
+	 * @param transition A value between zero and one.
 	 */
-	public void render() {
+	public void render(final double transition) {
+		double shortenedTransition = transition * _transitionFactor;
+
+		if (shortenedTransition > 1) {
+			shortenedTransition = 1;
+		}
+
 		Graphics2D g = _drawFrame.startRender();
 
-		_view.drawScaledContent(g);
+		_view.drawScaledContent(g, shortenedTransition);
 		_drawFrame.switchToUIRender();
-		_view.drawUnscaledContent(g);
+		_view.drawUnscaledContent(g, shortenedTransition);
 
 		_drawFrame.finishRender();
 	}

--- a/src/main/java/de/isibboi/agentsim/ui/GameUI.java
+++ b/src/main/java/de/isibboi/agentsim/ui/GameUI.java
@@ -110,18 +110,18 @@ public class GameUI implements View {
 	}
 
 	@Override
-	public void drawScaledContent(final Graphics2D g) {
+	public void drawScaledContent(final Graphics2D g, final double transition) {
 		// Draw map.
-		_game.getMap().draw(g);
+		_game.getMap().draw(g, transition);
 
 		// Draw entities.
 		if (_renderEntities) {
-			_game.getEntities().draw(g);
+			_game.getEntities().draw(g, transition);
 		}
 	};
 
 	@Override
-	public void drawUnscaledContent(final Graphics2D g) {
+	public void drawUnscaledContent(final Graphics2D g, final double transition) {
 		// Measure frame rate.
 		_frameRateMeter.update();
 		_frameRateLabel.setValue(_frameRateMeter.getValue());
@@ -134,7 +134,7 @@ public class GameUI implements View {
 
 		_renderer.setGraphics(g);
 		for (Drawable d : _drawables) {
-			d.draw(g);
+			d.draw(g, transition);
 		}
 	}
 

--- a/src/main/java/de/isibboi/agentsim/ui/View.java
+++ b/src/main/java/de/isibboi/agentsim/ui/View.java
@@ -31,13 +31,23 @@ public interface View extends UIMouseInputListener, UIActionListener, Updateable
 
 	/**
 	 * Draws the content that needs to be scaled when the game is for example zoomed.
+	 * The transition parameter determines where the entity is exactly drawn.
+	 * For zero, the entity should be drawn at the location from the last update, for one, it should be drawn at the current location.
+	 * Values between zero and one should be used for linear interpolation between old and new location.
+	 * 
 	 * @param g The graphics object used for drawing.
+	 * @param transition A value between zero and one.
 	 */
-	void drawScaledContent(Graphics2D g);
+	void drawScaledContent(Graphics2D g, double transition);
 
 	/**
 	 * Draws the content that doesn't need to be scaled.
+	 * The transition parameter determines where the entity is exactly drawn.
+	 * For zero, the entity should be drawn at the location from the last update, for one, it should be drawn at the current location.
+	 * Values between zero and one should be used for linear interpolation between old and new location.
+	 * 
 	 * @param g The graphics object used for drawing.
+	 * @param transition A value between zero and one.
 	 */
-	void drawUnscaledContent(Graphics2D g);
+	void drawUnscaledContent(Graphics2D g, double transition);
 }

--- a/src/main/java/de/isibboi/agentsim/ui/component/UIButton.java
+++ b/src/main/java/de/isibboi/agentsim/ui/component/UIButton.java
@@ -61,7 +61,7 @@ public class UIButton extends UILabel implements UIMouseInputListener {
 	}
 
 	@Override
-	public void draw(final Graphics2D g) {
+	public void draw(final Graphics2D g, final double transition) {
 		if (_mouseHovering) {
 			if (_mouseDown) {
 				getRenderer().drawClickedBox(getPosition().getX(), getPosition().getY(), getWidth(), getRenderer().getTextHeight() + 10);

--- a/src/main/java/de/isibboi/agentsim/ui/component/UILabel.java
+++ b/src/main/java/de/isibboi/agentsim/ui/component/UILabel.java
@@ -39,7 +39,7 @@ public class UILabel extends UIAbstractComponent {
 	}
 
 	@Override
-	public void draw(final Graphics2D g) {
+	public void draw(final Graphics2D g, final double transition) {
 		getRenderer().drawBox(getPosition().getX(), getPosition().getY(), getWidth(), getRenderer().getTextHeight() + 10);
 		getRenderer().drawText(_text, getPosition().getX() + 5, getPosition().getY() + 5 + getRenderer().getTextHeight());
 	}


### PR DESCRIPTION
+ Added transition parameter to render methods.
+ Added transition aware SlowFrameRateStabilizer.
+ Made entities hold positions for a moment via
core.render.transitionAmount parameter. This is currently set to 1, so
does nothing.
* Made MapEntities always draw themselves inside a unit square at (0,
0), moving translation calculation to the MapEntity class.